### PR TITLE
Focusable search, with clicking and key bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,15 @@ Desktop.ini
 *.iml
 *.ipr
 *.iws
+
+# eclipse
+.classpath
+.project
+.settings/*
+bin/*
+
+# gradle
+.gradle/*
+
+# other
+build.bat

--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@ filename=EasyCrafting
 version=2.0.1
 
 version_mc=1.7.10
-version_forge=10.13.0.1208
+version_forge=10.13.2.1235
 
 #ftp_location=ftp://localhost/maven/
 ftp_location=ftp://lepko.net/domains/lepko.net/public_html/mods/maven/

--- a/src/main/java/net/lepko/easycrafting/EasyCrafting.java
+++ b/src/main/java/net/lepko/easycrafting/EasyCrafting.java
@@ -7,8 +7,10 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.relauncher.Side;
 import net.lepko.easycrafting.core.block.ModBlocks;
 import net.lepko.easycrafting.core.config.ConfigHandler;
+import net.lepko.easycrafting.core.config.KeyBindings;
 import net.lepko.easycrafting.core.network.PacketHandler;
 import net.lepko.easycrafting.core.recipe.RecipeManager;
 import net.lepko.easycrafting.core.util.ItemMap;
@@ -16,42 +18,43 @@ import net.lepko.easycrafting.core.util.ItemMap;
 @Mod(modid = Ref.MOD_ID, useMetadata = true)
 public class EasyCrafting {
 
-	//TODO: block.shouldCheckWeakPower()
-		//block.onNeighbourTileChange()
-		//RIGHT CLICK SEARCH BAR DELETES ALL TEXT
-		//CREDIT ElementalRobot50 for Auto Crafting Table textures
+	// TODO: block.shouldCheckWeakPower()
+	// block.onNeighbourTileChange()
+	// CREDIT ElementalRobot50 for Auto Crafting Table textures
 
+	@Instance(Ref.MOD_ID)
+	public static EasyCrafting INSTANCE;
 
-    @Instance(Ref.MOD_ID)
-    public static EasyCrafting INSTANCE;
+	@EventHandler
+	public void preInit(FMLPreInitializationEvent event) {
+		if (event.getSide() == Side.CLIENT)
+			KeyBindings.init();
+		Ref.init();
+		ConfigHandler.initialize(event.getSuggestedConfigurationFile());
 
-    @EventHandler
-    public void preInit(FMLPreInitializationEvent event) {
-        Ref.init();
-        ConfigHandler.initialize(event.getSuggestedConfigurationFile());
+		ModBlocks.setupBlocks();
+	}
 
-        ModBlocks.setupBlocks();
-    }
+	@EventHandler
+	public void init(FMLInitializationEvent event) {
+		Ref.PROXY.registerHandlers();
+		Ref.PROXY.registerCommands();
 
-    @EventHandler
-    public void init(FMLInitializationEvent event) {
-        Ref.PROXY.registerHandlers();
-        Ref.PROXY.registerCommands();
+		PacketHandler.init();
+	}
 
-        PacketHandler.init();
-    }
+	@EventHandler
+	public void postInit(FMLPostInitializationEvent event) {
+		ModBlocks.setupRecipes();
+		// XXX: VersionHelper.performCheck();
+	}
 
-    @EventHandler
-    public void postInit(FMLPostInitializationEvent event) {
-        ModBlocks.setupRecipes();
-        //XXX: VersionHelper.performCheck();
-    }
+	@EventHandler
+	public void available(FMLLoadCompleteEvent event) {
+		ItemMap.build();
 
-    @EventHandler
-    public void available(FMLLoadCompleteEvent event) {
-        ItemMap.build();
-
-        // This fires after the recipes are sorted by forge; Mods should not add/remove recipes after this point!!
-        RecipeManager.scanRecipes();
-    }
+		// This fires after the recipes are sorted by forge; Mods should not
+		// add/remove recipes after this point!!
+		RecipeManager.scanRecipes();
+	}
 }

--- a/src/main/java/net/lepko/easycrafting/core/block/BlockTable.java
+++ b/src/main/java/net/lepko/easycrafting/core/block/BlockTable.java
@@ -32,7 +32,6 @@ public class BlockTable extends BlockContainer {
         setStepSound(soundTypeWood);
         setBlockName(Ref.addDomain("table"));
         setBlockTextureName(Ref.addDomain("table"));
-        setCreativeTab(CreativeTabs.tabDecorations);
     }
 
     @Override
@@ -82,7 +81,7 @@ public class BlockTable extends BlockContainer {
             list.add(new ItemStack(item, 1, meta));
         }
     }
-
+    
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
         TileEntity te = world.getTileEntity(x, y, z);

--- a/src/main/java/net/lepko/easycrafting/core/block/ItemBlockTable.java
+++ b/src/main/java/net/lepko/easycrafting/core/block/ItemBlockTable.java
@@ -7,23 +7,23 @@ import net.minecraft.item.ItemStack;
 
 public class ItemBlockTable extends ItemBlock {
 
-    public ItemBlockTable(Block block) {
-        super(block);
-        setUnlocalizedName(Ref.addDomain("table"));
-        setHasSubtypes(true);
-    }
+	public ItemBlockTable(Block block) {
+		super(block);
+		setUnlocalizedName(Ref.addDomain("table"));
+		setHasSubtypes(true);
+	}
 
-    @Override
-    public int getMetadata(int meta) {
-        return meta;
-    }
+	@Override
+	public int getMetadata(int meta) {
+		return meta;
+	}
 
-    @Override
-    public String getUnlocalizedName(ItemStack stack) {
-        int meta = stack.getItemDamage();
-        if (meta >= 0 && meta < BlockTable.names.length) {
-            return this.getUnlocalizedName() + "." + BlockTable.names[meta];
-        }
-        return "missingno";
-    }
+	@Override
+	public String getUnlocalizedName(ItemStack stack) {
+		int meta = stack.getItemDamage();
+		if (meta >= 0 && meta < BlockTable.names.length) {
+			return this.getUnlocalizedName() + "." + BlockTable.names[meta];
+		}
+		return "missingno";
+	}
 }

--- a/src/main/java/net/lepko/easycrafting/core/block/ModBlocks.java
+++ b/src/main/java/net/lepko/easycrafting/core/block/ModBlocks.java
@@ -1,24 +1,39 @@
 package net.lepko.easycrafting.core.block;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.lepko.easycrafting.Ref;
 import net.minecraft.block.Block;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 @GameRegistry.ObjectHolder(Ref.MOD_ID)
 public class ModBlocks {
 
+	public static CreativeTabs easyCraftingTab = new CreativeTabs("easyCrafting") {
+		@Override
+		@SideOnly(Side.CLIENT)
+		public Item getTabIconItem() {
+			return get("easyCraftingTable").getItem();
+		}
+	};
+	
     public static final Block table = new BlockTable();
 
     public static void setupBlocks() {
         GameRegistry.registerBlock(table, ItemBlockTable.class, "table");
+        
         GameRegistry.registerCustomItemStack("easyCraftingTable", new ItemStack(table, 1, 0));
         GameRegistry.registerCustomItemStack("autoCraftingTable", new ItemStack(table, 1, 1));
 
         GameRegistry.registerTileEntity(TileEntityEasyCrafting.class, "EasyCraftingTableTE");
         GameRegistry.registerTileEntity(TileEntityAutoCrafting.class, "AutoCraftingTableTE");
+        
+        table.setCreativeTab(easyCraftingTab);
     }
 
     public static void setupRecipes() {

--- a/src/main/java/net/lepko/easycrafting/core/config/KeyBindings.java
+++ b/src/main/java/net/lepko/easycrafting/core/config/KeyBindings.java
@@ -1,0 +1,28 @@
+package net.lepko.easycrafting.core.config;
+
+import net.minecraft.client.settings.KeyBinding;
+
+import org.lwjgl.input.Keyboard;
+
+import cpw.mods.fml.client.registry.ClientRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class KeyBindings {
+
+	public static KeyBinding focusSearch;
+
+	public static void init() {
+		// Define the "focus" binding, with (unlocalized) name "key.focus" and
+		// the category with (unlocalized) name "key.categories.EasyCrafting"
+		// and
+		// key code 33 ("F", LWJGL constant: Keyboard.KEY_F)
+		focusSearch = new KeyBinding("key.focus", Keyboard.KEY_F,
+				"key.categories.easycrafting");
+
+		// Register KeyBinding to the ClientRegistry
+		ClientRegistry.registerKeyBinding(focusSearch);
+	}
+
+}

--- a/src/main/java/net/lepko/easycrafting/core/inventory/gui/GuiEasyCrafting.java
+++ b/src/main/java/net/lepko/easycrafting/core/inventory/gui/GuiEasyCrafting.java
@@ -1,12 +1,14 @@
 package net.lepko.easycrafting.core.inventory.gui;
 
-import codechicken.nei.guihook.IContainerTooltipHandler;
-import com.google.common.collect.ImmutableList;
-import cpw.mods.fml.common.Optional;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
 import net.lepko.easycrafting.Ref;
 import net.lepko.easycrafting.core.block.ModBlocks;
 import net.lepko.easycrafting.core.block.TileEntityEasyCrafting;
 import net.lepko.easycrafting.core.config.ConfigHandler;
+import net.lepko.easycrafting.core.config.KeyBindings;
 import net.lepko.easycrafting.core.inventory.ContainerEasyCrafting;
 import net.lepko.easycrafting.core.network.PacketHandler;
 import net.lepko.easycrafting.core.network.message.MessageEasyCrafting;
@@ -31,496 +33,622 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.oredict.OreDictionary;
+
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import codechicken.nei.guihook.IContainerTooltipHandler;
+
+import com.google.common.collect.ImmutableList;
+
+import cpw.mods.fml.common.Optional;
 
 @Optional.Interface(iface = "codechicken.nei.guihook.IContainerTooltipHandler", modid = "NotEnoughItems")
-public class GuiEasyCrafting extends GuiTabbed implements IContainerTooltipHandler {
-
-    private class TabEasyCrafting extends Tab {
-        public TabEasyCrafting(ItemStack iconStack, String tooltip) {
-            super(iconStack, tooltip);
-        }
-
-        @Override
-        public void onTabSelected() {
-            updateSearch(true);
-        }
-    }
-
-    private static final ResourceLocation GUI_TEXTURE = new ResourceLocation(Ref.RES_DOMAIN, "textures/gui/easycraftinggui.png");
-    private static String LAST_SEARCH = "";
-    private static boolean WORKER_LOCKED = false;
-
-    public List<WrappedRecipe> shownRecipes;
-    public List<WrappedRecipe> craftableRecipes = ImmutableList.of();
-
-    private int currentRowOffset = 0;
-    private int maxRowOffset = 0;
-    private float currentScrollValue = 0;
-    private boolean wasClicking = false;
-    private boolean isDraggingScrollBar = false;
-    private boolean[] canCraftCache;
-
-    private final IInventory tileInventory;
-    private GuiTextField searchField;
-
-    public GuiEasyCrafting(InventoryPlayer playerInventory, TileEntityEasyCrafting tileInventory) {
-        super(new ContainerEasyCrafting(playerInventory, tileInventory));
-        this.tileInventory = tileInventory;
-        ySize = 235;
-    }
-
-    @Override
-    public void initGui() {
-        super.initGui();
-        Keyboard.enableRepeatEvents(true);
-        searchField = new GuiTextField(fontRendererObj, guiLeft + 82, guiTop + 6, 89, fontRendererObj.FONT_HEIGHT);
-        searchField.setMaxStringLength(32);
-        searchField.setEnableBackgroundDrawing(false);
-        searchField.setVisible(true);
-        searchField.setTextColor(0xFFFFFF);
-        searchField.setCanLoseFocus(false);
-        searchField.setFocused(true);
-        searchField.setText(LAST_SEARCH);
-    }
-
-    @Override
-    public void initTabs() {
-        tabGroup.addTab(new TabEasyCrafting(new ItemStack(ModBlocks.table), "Available"));
-        tabGroup.addTab(new TabEasyCrafting(new ItemStack(Items.compass), "Search"));
-    }
-
-    @Override
-    public void onGuiClosed() {
-        super.onGuiClosed();
-        Keyboard.enableRepeatEvents(false);
-    }
-
-    @Override
-    public void drawScreen(int mouseX, int mouseY, float time) {
-        // XXX: Check lock on worker thread
-        WORKER_LOCKED = !RecipeChecker.INSTANCE.done;
-
-        // Handle scrollbar dragging
-        boolean leftMouseDown = Mouse.isButtonDown(0);
-        int left = guiLeft + 155;
-        int top = guiTop + 18;
-        int right = left + 14;
-        int bottom = top + 89;
-
-        if (!wasClicking && leftMouseDown && mouseX >= left && mouseY >= top && mouseX < right && mouseY < bottom) {
-            isDraggingScrollBar = maxRowOffset > 0;
-        } else if (!leftMouseDown) {
-            isDraggingScrollBar = false;
-        }
-
-        wasClicking = leftMouseDown;
-
-        if (isDraggingScrollBar) {
-            setScrollValue((mouseY - top - 7.5F) / (bottom - top - 15.0F));
-        }
-
-        super.drawScreen(mouseX, mouseY, time);
-    }
-
-    @Override
-    protected void drawGuiContainerBackgroundLayer(float f, int i, int j) {
-        // Background
-        mc.renderEngine.bindTexture(GUI_TEXTURE);
-        drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
-
-        // Tabs
-        super.drawGuiContainerBackgroundLayer(f, i, j);
-
-        // Scrollbar
-        int scrollTextureX = maxRowOffset == 0 ? 12 : 0;
-        drawTexturedModalRect(guiLeft + 156, guiTop + 17 + (int) (currentScrollValue * 73.0F), scrollTextureX, 240, 12, 16);
-
-        // Search
-        int searchTextureX = xSize - 90 - 7;
-        drawTexturedModalRect(guiLeft + searchTextureX, guiTop + 4, searchTextureX, 256 - 12, 90, 12);
-        searchField.drawTextBox();
-
-        // Output slot backgrounds
-        if (canCraftCache != null && currentTab != 0) {
-            int offset = currentRowOffset * 8;
-            for (int k = 0; k < 40 && k + offset < canCraftCache.length; k++) {
-                drawSlotBackground(inventorySlots.getSlot(k), canCraftCache[k + offset]);
-            }
-        }
-
-        // Storage slots background
-        for (int l = 0; l < 18; l++) {
-            drawSlotBackground(inventorySlots.getSlot(l + 40), false);
-        }
-    }
-
-    @Override
-    protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
-        String title = "Easy Crafting";
-        if (WORKER_LOCKED) {
-            title = "Searching...";
-        }
-        fontRendererObj.drawString(title, 7, 6, 0x404040);
-
-        super.drawGuiContainerForegroundLayer(mouseX, mouseY);
-    }
-
-    @Override
-    protected void keyTyped(char par1, int par2) {
-        if (!checkHotbarKeys(par2)) {
-            if (searchField.textboxKeyTyped(par1, par2)) {
-                updateSearch(true);
-            } else {
-                super.keyTyped(par1, par2);
-            }
-        }
-    }
-
-    @Override
-    public void handleMouseInput() {
-        int mouseScroll = Mouse.getEventDWheel();
-        if (mouseScroll == 0) { // Bypass NEI fast transfer manager
-            super.handleMouseInput();
-        } else {
-            setRowOffset(currentRowOffset + (mouseScroll > 0 ? -1 : 1));
-        }
-    }
-
-    // button:
-    // 0 -> left mouse
-    // 1 -> action=0 or 1 -> right mouse
-    // _____action=5 -> left click dragged over
-    // 2 -> middle mouse
-    // 5 -> action=5 -> right click dragged over
-    //
-    // action:
-    // 0 -> click
-    // 1 -> shift click
-    // 2 -> swap with slot in hotbar (button is 0-8)
-    // 3 -> pick block
-    // 4 -> drop block
-    // 5 -> dragged stack
-    // 6 -> double click
-    @Override
-    protected void handleMouseClick(Slot slot, int slotIndex, int button, int action) {
-        if (slotIndex >= 0 && slotIndex < 40) {
-            onCraftingSlotClick(slot, slotIndex, button, action);
-        } else {
-            super.handleMouseClick(slot, slotIndex, button, action);
-        }
-    }
-
-    private void onCraftingSlotClick(Slot slot, int slotIndex, int button, int action) {
-        Ref.LOGGER.trace("Clicked: " + slot.getClass().getSimpleName() + "@" + slotIndex + ", button=" + button + ", action=" + action + ", stack=" + slot.getStack());
-
-        if (action > 1 || button > 1 || !slot.getHasStack()) {
-            return;
-        }
-
-        ItemStack heldStack = mc.thePlayer.inventory.getItemStack();
-        ItemStack slotStack = slot.getStack();
-
-        WrappedRecipe recipe = null;
-        int recipeIndex = slotIndex + currentRowOffset * 8;
-        if (recipeIndex >= 0 && shownRecipes != null && recipeIndex < shownRecipes.size()) {
-            WrappedRecipe r = shownRecipes.get(recipeIndex);
-            if (StackUtils.areEqualNoSizeNoNBT(r.getOutput(), slotStack) && craftableRecipes != null && craftableRecipes.contains(r)) {
-                recipe = r;
-            }
-        }
-        if (recipe == null) {
-            return;
-        }
-
-        // slotStack already has a stack from recipe.handler.getCraftingResult()
-        ItemStack finalStack = slotStack.copy();
-        int finalStackSize = 0;
-
-        if (heldStack == null) {
-            finalStackSize = finalStack.stackSize;
-        } else if (StackUtils.canStack(slotStack, heldStack) == 0) {
-            finalStackSize = finalStack.stackSize + heldStack.stackSize;
-        }
-
-        if (finalStackSize > 0) {
-            boolean isRightClick = button == 1;
-            boolean isShiftClick = action == 1;
-
-            PacketHandler.INSTANCE.sendToServer(new MessageEasyCrafting(recipe, isRightClick, isShiftClick));
-
-            if (isRightClick) { // Right click; craft until max stack
-                int maxTimes = RecipeHelper.calculateCraftingMultiplierUntilMaxStack(slotStack, heldStack);
-                int timesCrafted = RecipeHelper.canCraft(recipe, mc.thePlayer.inventory, RecipeManager.getAllRecipes(), false, maxTimes, ConfigHandler.MAX_RECURSION);
-                if (timesCrafted > 0) {
-                    finalStack.stackSize = finalStackSize + (timesCrafted - 1) * finalStack.stackSize;
-                    mc.thePlayer.inventory.setItemStack(finalStack);
-                }
-            } else if (isShiftClick) {
-                int maxTimes = RecipeHelper.calculateCraftingMultiplierUntilMaxStack(slotStack, null);
-                int timesCrafted = RecipeHelper.canCraft(recipe, mc.thePlayer.inventory, RecipeManager.getAllRecipes(), false, maxTimes, ConfigHandler.MAX_RECURSION);
-                if (timesCrafted > 0) {
-                    finalStack.stackSize *= timesCrafted; //ignore finalStackSize; it might contain heldStack size
-                    InventoryUtils.addItemToInventory(mc.thePlayer.inventory, finalStack);
-                }
-            } else { // Left click; craft once
-                finalStack.stackSize = finalStackSize;
-                mc.thePlayer.inventory.setItemStack(finalStack);
-            }
-        }
-    }
-
-    private void drawSlotBackground(Slot slot, boolean canCraft) {
-        int x = guiLeft + slot.xDisplayPosition;
-        int y = guiTop + slot.yDisplayPosition;
-        int color = canCraft ? 0x8000A000 : 0x80A00000;
-        Gui.drawRect(x, y, x + 16, y + 16, color);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void updateSearch(boolean scrollToTop) {
-        List<WrappedRecipe> all = currentTab == 0 ? craftableRecipes : RecipeManager.getAllRecipes();
-        List<WrappedRecipe> list = new ArrayList<WrappedRecipe>();
-        if (all == null || searchField == null) {
-            return;
-        }
-        LAST_SEARCH = searchField.getText().toLowerCase();
-        if (!LAST_SEARCH.trim().isEmpty()) {
-            for (WrappedRecipe recipe : all) {
-                List<String> tips = recipe.getOutput().getTooltip(mc.thePlayer, mc.gameSettings.advancedItemTooltips);
-                for (String tip : tips) {
-                    if (tip.toLowerCase().contains(LAST_SEARCH)) {
-                        list.add(recipe);
-                        break;
-                    }
-                }
-            }
-            shownRecipes = list;
-        } else {
-            shownRecipes = all;
-        }
-
-        maxRowOffset = (int) (Math.ceil(shownRecipes.size() / 8.0D) - 5);
-        maxRowOffset = maxRowOffset < 0 ? 0 : maxRowOffset;
-
-        rebuildCanCraftCache();
-        setRowOffset(scrollToTop ? 0 : currentRowOffset);
-    }
-
-    public void refreshCraftingOutput() {
-        craftableRecipes = ImmutableList.copyOf(RecipeChecker.INSTANCE.recipes);
-        updateSearch(false);
-    }
-
-    private void rebuildCanCraftCache() {
-        canCraftCache = new boolean[shownRecipes.size()];
-        for (int i = 0; i < shownRecipes.size(); i++) {
-            canCraftCache[i] = craftableRecipes.contains(shownRecipes.get(i));
-        }
-    }
-
-    private void setRowOffset(int rowOffset) {
-        currentRowOffset = MathHelper.clamp_int(rowOffset, 0, maxRowOffset);
-        currentScrollValue = MathHelper.clamp_float(currentRowOffset / (float) maxRowOffset, 0F, 1F);
-        setSlots();
-    }
-
-    private void setScrollValue(float scrollValue) {
-        currentScrollValue = MathHelper.clamp_float(scrollValue, 0F, 1F);
-        currentRowOffset = MathHelper.clamp_int((int) (currentScrollValue * maxRowOffset + 0.5F), 0, maxRowOffset);
-        setSlots();
-    }
-
-    private void setSlots() {
-        if (shownRecipes != null) {
-            int offset = currentRowOffset * 8;
-            for (int i = 0; i < 40; i++) {
-                if (i + offset >= shownRecipes.size() || i + offset < 0) {
-                    tileInventory.setInventorySlotContents(i, null);
-                } else {
-                    WrappedRecipe recipe = shownRecipes.get(i + offset);
-                    ItemStack is = recipe.handler.getCraftingResult(recipe, recipe.usedIngredients);
-                    tileInventory.setInventorySlotContents(i, is);
-                }
-            }
-        }
-    }
-
-    // START NEI
-    @Override
-    public List<String> handleTooltip(GuiContainer gui, int mouseX, int mouseY, List<String> currentTip) {
-        return currentTip;
-    }
-
-    @Override
-    public List<String> handleItemDisplayName(GuiContainer gui, ItemStack stack, List<String> currentTip) {
-        return currentTip;
-    }
-
-    @Override
-    public List<String> handleItemTooltip(GuiContainer gui, ItemStack stack, int mouseX, int mouseY, List<String> currentTip) {
-        if (!drawCustomTooltip(stack, mouseX, mouseY, currentTip)) {
-            return currentTip;
-        }
-        // Hack to always return empty list
-        return new LinkedList<String>() {
-            @Override
-            public int size() {
-                return 0;
-            }
-        };
-    }
-    // END NEI
-
-    @SuppressWarnings("unchecked")
-    @Override
-    protected void renderToolTip(ItemStack stack, int mouseX, int mouseY) {
-        if (!drawCustomTooltip(stack, mouseX, mouseY, (List<String>) stack.getTooltip(mc.thePlayer, mc.gameSettings.advancedItemTooltips))) {
-            super.renderToolTip(stack, mouseX, mouseY);
-        }
-    }
-
-    private boolean drawCustomTooltip(ItemStack stack, int mouseX, int mouseY, List<String> currentTip) {
-        if (isCtrlKeyDown() && currentTip != null && !currentTip.isEmpty()) {
-            for (int j = 0; j < 40; j++) {
-                Slot slot = inventorySlots.getSlot(j);
-                //isPointInRegion
-                if (func_146978_c(slot.xDisplayPosition, slot.yDisplayPosition, 16, 16, mouseX, mouseY)) {
-                    FontRenderer font = stack.getItem().getFontRenderer(stack);
-                    String itemName = currentTip.get(0);
-                    List<String> list = ImmutableList.of(stack.getRarity().rarityColor + itemName);
-                    drawHoveringText(list, mouseX, mouseY, font == null ? fontRendererObj : font);
-
-                    boolean leftSide = mouseX + 12 + fontRendererObj.getStringWidth(itemName) > width;
-                    drawIngredientTooltip(j, mouseX, mouseY, leftSide);
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private void drawIngredientTooltip(int slotIndex, int mouseX, int mouseY, boolean leftSide) {
-
-        WrappedRecipe recipe = null;
-
-        int recipe_index = slotIndex + currentRowOffset * 8;
-        if (recipe_index >= 0 && shownRecipes != null && recipe_index < shownRecipes.size()) {
-            WrappedRecipe r = shownRecipes.get(recipe_index);
-            if (StackUtils.areCraftingEquivalent(r.getOutput(), inventorySlots.getSlot(slotIndex).getStack())) {
-                recipe = r;
-            }
-        }
-
-        if (recipe == null) {
-            return;
-        }
-
-        boolean canCraft = canCraftCache[recipe_index];
-        List<WrappedStack> ingredientList = canCraft && !recipe.usedIngredients.isEmpty() ? StackUtils.collateStacks(recipe.usedIngredients) : recipe.collatedInputs;
-
-        if (ingredientList != null && !ingredientList.isEmpty()) {
-            int width = 16;
-            int height = 16;
-            int xPos = mouseX + 12;
-            int yPos = mouseY - 12 + 14;
-
-            if (ingredientList.size() > 1) {
-                width += (ingredientList.size() - 1) * (width + 2);
-            }
-
-            if (leftSide) {
-                xPos -= 28 + width;
-            }
-
-            // red: 0x50FF0000;// green: 0x5000A700;// vanilla purple: 0x505000FF;
-            int bgColor = 0xF0100010;
-            int borderColor = canCraft ? 0x5000A700 : 0x50FF0000;
-            int borderColorDark = (borderColor & 0xFEFEFE) >> 1 | borderColor & 0xFF000000;
-
-            zLevel += 500.0F;
-            itemRender.zLevel += 500.0F;
-
-            RenderHelper.disableStandardItemLighting();
-            GL11.glDisable(GL11.GL_LIGHTING);
-            GL11.glDisable(GL11.GL_DEPTH_TEST);
-            GL11.glDisable(GL12.GL_RESCALE_NORMAL);
-
-            drawGradientRect(xPos - 3, yPos - 4, xPos + width + 3, yPos - 3, bgColor, bgColor);
-            drawGradientRect(xPos - 3, yPos + height + 3, xPos + width + 3, yPos + height + 4, bgColor, bgColor);
-            drawGradientRect(xPos - 3, yPos - 3, xPos + width + 3, yPos + height + 3, bgColor, bgColor);
-            drawGradientRect(xPos - 4, yPos - 3, xPos - 3, yPos + height + 3, bgColor, bgColor);
-            drawGradientRect(xPos + width + 3, yPos - 3, xPos + width + 4, yPos + height + 3, bgColor, bgColor);
-
-            drawGradientRect(xPos - 3, yPos - 3 + 1, xPos - 3 + 1, yPos + height + 3 - 1, borderColor, borderColorDark);
-            drawGradientRect(xPos + width + 2, yPos - 3 + 1, xPos + width + 3, yPos + height + 3 - 1, borderColor, borderColorDark);
-            drawGradientRect(xPos - 3, yPos - 3, xPos + width + 3, yPos - 3 + 1, borderColor, borderColor);
-            drawGradientRect(xPos - 3, yPos + height + 2, xPos + width + 3, yPos + height + 3, borderColorDark, borderColorDark);
-
-            RenderHelper.enableGUIStandardItemLighting();
-            GL11.glEnable(GL11.GL_LIGHTING);
-            GL11.glEnable(GL11.GL_DEPTH_TEST);
-            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
-
-            for (WrappedStack ws : ingredientList) {
-                renderItem(xPos, yPos, ws);
-                xPos += 18;
-            }
-
-            GL11.glDisable(GL12.GL_RESCALE_NORMAL);
-            GL11.glDisable(GL11.GL_DEPTH_TEST);
-            GL11.glDisable(GL11.GL_LIGHTING);
-
-            zLevel -= 500.0F;
-            itemRender.zLevel -= 500.0F;
-        }
-    }
-
-    private void renderItem(int xPos, int yPos, WrappedStack ws) {
-        ItemStack is = null;
-
-        int count = 0;
-        for (ItemStack stack : ws.stacks) {
-            if (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE && stack.getHasSubtypes()) {
-                count += ItemMap.get(stack.getItem()).size();
-            } else {
-                count++;
-            }
-        }
-
-        int num = (int) ((mc.theWorld.getTotalWorldTime() / 10) % count);
-
-        count = 0;
-        for (ItemStack stack : ws.stacks) {
-            if (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE && stack.getHasSubtypes()) {
-                List<ItemStack> all = ItemMap.get(stack.getItem());
-                if (num >= count && num < count + all.size()) {
-                    is = StackUtils.copyStack(all.get(num - count), ws.size);
-                    break;
-                }
-                count += all.size();
-            } else {
-                if (num == count) {
-                    is = StackUtils.copyStack(stack, ws.size);
-                    break;
-                }
-                count++;
-            }
-        }
-
-        //
-        if (is != null) {
-            itemRender.renderItemAndEffectIntoGUI(fontRendererObj, mc.renderEngine, is, xPos, yPos);
-            itemRender.renderItemOverlayIntoGUI(fontRendererObj, mc.renderEngine, is, xPos, yPos);
-        } else {
-            Ref.LOGGER.warn("Error rendering stack in recipe tooltip: is == null");
-        }
-    }
+public class GuiEasyCrafting extends GuiTabbed implements
+		IContainerTooltipHandler {
+
+	private class TabEasyCrafting extends Tab {
+		public TabEasyCrafting(ItemStack iconStack, String tooltip) {
+			super(iconStack, tooltip);
+		}
+
+		@Override
+		public void onTabSelected() {
+			updateSearch(true);
+		}
+	}
+
+	private static final ResourceLocation GUI_TEXTURE = new ResourceLocation(
+			Ref.RES_DOMAIN, "textures/gui/easycraftinggui.png");
+	private static String LAST_SEARCH = "";
+	private static boolean WORKER_LOCKED = false;
+
+	public List<WrappedRecipe> shownRecipes;
+	public List<WrappedRecipe> craftableRecipes = ImmutableList.of();
+
+	private int currentRowOffset = 0;
+	private int maxRowOffset = 0;
+	private float currentScrollValue = 0;
+	private boolean wasClicking = false;
+	private boolean isDraggingScrollBar = false;
+	private boolean[] canCraftCache;
+
+	private final IInventory tileInventory;
+	private GuiTextField searchField;
+
+	public GuiEasyCrafting(InventoryPlayer playerInventory,
+			TileEntityEasyCrafting tileInventory) {
+		super(new ContainerEasyCrafting(playerInventory, tileInventory));
+		this.tileInventory = tileInventory;
+		ySize = 235;
+	}
+
+	@Override
+	public void initGui() {
+		super.initGui();
+		Keyboard.enableRepeatEvents(true);
+		searchField = new GuiTextField(fontRendererObj, guiLeft + 82,
+				guiTop + 6, 89, fontRendererObj.FONT_HEIGHT) {
+			@Override
+			public void mouseClicked(int x, int y, int button) {
+				boolean isInsideSearchBox = x >= this.xPosition
+						&& x < this.xPosition + this.width
+						&& y >= this.yPosition
+						&& y < this.yPosition + this.height;
+				if (isInsideSearchBox) {
+					if (button == 1) {
+						// On right click remove text and add focus.
+						this.setFocused(true);
+						this.setText("");
+						updateSearch(true);
+					} else if (button == 2) {
+						// On middle click toggle focus (also removes text)
+						setSearchFocused(!this.isFocused());
+					} else {
+						// On any other mouse click, focus
+						setSearchFocused(true);
+						// Super implementation will only change cursor position
+						// when using left click
+						super.mouseClicked(x, y, button);
+					}
+				} else {
+					// A click outside the text box happened. We don't want to
+					// remove the search just in case it's still being used. But
+					// we do want to remove focus to use other key bindings,
+					// such as nei's recipe key binding or nei's utility key
+					// binding.
+					this.setFocused(false);
+				}
+			}
+
+		};
+		searchField.setMaxStringLength(32);
+		searchField.setEnableBackgroundDrawing(false);
+		searchField.setVisible(true);
+		searchField.setTextColor(0xFFFFFF);
+		searchField.setCanLoseFocus(true);
+		searchField.setFocused(false);
+		searchField.setText(LAST_SEARCH);
+	}
+
+	@Override
+	protected void mouseClicked(int mouseX, int mouseY, int button) {
+		super.mouseClicked(mouseX, mouseY, button);
+		searchField.mouseClicked(mouseX, mouseY, button);
+	}
+
+	@Override
+	public void initTabs() {
+		tabGroup.addTab(new TabEasyCrafting(new ItemStack(ModBlocks.table),
+				"Available"));
+		tabGroup.addTab(new TabEasyCrafting(new ItemStack(Items.compass),
+				"Search"));
+	}
+
+	@Override
+	public void onGuiClosed() {
+		super.onGuiClosed();
+		Keyboard.enableRepeatEvents(false);
+	}
+
+	@Override
+	public void drawScreen(int mouseX, int mouseY, float time) {
+		// XXX: Check lock on worker thread
+		WORKER_LOCKED = !RecipeChecker.INSTANCE.done;
+
+		// Handle scrollbar dragging
+		boolean leftMouseDown = Mouse.isButtonDown(0);
+		int left = guiLeft + 155;
+		int top = guiTop + 18;
+		int right = left + 14;
+		int bottom = top + 89;
+
+		if (!wasClicking && leftMouseDown && mouseX >= left && mouseY >= top
+				&& mouseX < right && mouseY < bottom) {
+			isDraggingScrollBar = maxRowOffset > 0;
+		} else if (!leftMouseDown) {
+			isDraggingScrollBar = false;
+		}
+
+		wasClicking = leftMouseDown;
+
+		if (isDraggingScrollBar) {
+			setScrollValue((mouseY - top - 7.5F) / (bottom - top - 15.0F));
+		}
+
+		super.drawScreen(mouseX, mouseY, time);
+	}
+
+	@Override
+	protected void drawGuiContainerBackgroundLayer(float f, int i, int j) {
+		// Background
+		mc.renderEngine.bindTexture(GUI_TEXTURE);
+		drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
+
+		// Tabs
+		super.drawGuiContainerBackgroundLayer(f, i, j);
+
+		// Scrollbar
+		int scrollTextureX = maxRowOffset == 0 ? 12 : 0;
+		drawTexturedModalRect(guiLeft + 156, guiTop + 17
+				+ (int) (currentScrollValue * 73.0F), scrollTextureX, 240, 12,
+				16);
+
+		// Search
+		int searchTextureX = xSize - 90 - 7;
+		drawTexturedModalRect(guiLeft + searchTextureX, guiTop + 4,
+				searchTextureX, 256 - 12, 90, 12);
+		searchField.drawTextBox();
+
+		// Output slot backgrounds
+		if (canCraftCache != null && currentTab != 0) {
+			int offset = currentRowOffset * 8;
+			for (int k = 0; k < 40 && k + offset < canCraftCache.length; k++) {
+				drawSlotBackground(inventorySlots.getSlot(k), canCraftCache[k
+						+ offset]);
+			}
+		}
+
+		// Storage slots background
+		for (int l = 0; l < 18; l++) {
+			drawSlotBackground(inventorySlots.getSlot(l + 40), false);
+		}
+	}
+
+	@Override
+	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
+		String title = "Easy Crafting";
+		if (WORKER_LOCKED) {
+			title = "Searching...";
+		}
+		fontRendererObj.drawString(title, 7, 6, 0x404040);
+
+		super.drawGuiContainerForegroundLayer(mouseX, mouseY);
+	}
+
+	@Override
+	protected void keyTyped(char keyChar, int keyCode) {
+		if (!searchField.isFocused()) {
+			if (KeyBindings.focusSearch.getKeyCode() == keyCode) {
+				setSearchFocused(true);
+			} else {
+				super.keyTyped(keyChar, keyCode);
+			}
+		} else if (!checkHotbarKeys(keyCode)) {
+			if (keyCode == 1) {
+				setSearchFocused(false);
+			} else if (searchField.textboxKeyTyped(keyChar, keyCode)) {
+				updateSearch(true);
+			} else {
+				super.keyTyped(keyChar, keyCode);
+			}
+		}
+	}
+
+	private void setSearchFocused(boolean focus) {
+		searchField.setFocused(focus);
+		if (!focus) {
+			searchField.setText("");
+			updateSearch(true);
+		}
+	}
+
+	@Override
+	public void handleMouseInput() {
+		int mouseScroll = Mouse.getEventDWheel();
+		if (mouseScroll == 0) { // Bypass NEI fast transfer manager
+			super.handleMouseInput();
+		} else {
+			setRowOffset(currentRowOffset + (mouseScroll > 0 ? -1 : 1));
+		}
+	}
+
+	// button:
+	// 0 -> left mouse
+	// 1 -> action=0 or 1 -> right mouse
+	// _____action=5 -> left click dragged over
+	// 2 -> middle mouse
+	// 5 -> action=5 -> right click dragged over
+	//
+	// action:
+	// 0 -> click
+	// 1 -> shift click
+	// 2 -> swap with slot in hotbar (button is 0-8)
+	// 3 -> pick block
+	// 4 -> drop block
+	// 5 -> dragged stack
+	// 6 -> double click
+	@Override
+	protected void handleMouseClick(Slot slot, int slotIndex, int button,
+			int action) {
+		if (slotIndex >= 0 && slotIndex < 40) {
+			onCraftingSlotClick(slot, slotIndex, button, action);
+		} else {
+			super.handleMouseClick(slot, slotIndex, button, action);
+		}
+	}
+
+	private void onCraftingSlotClick(Slot slot, int slotIndex, int button,
+			int action) {
+		Ref.LOGGER.trace("Clicked: " + slot.getClass().getSimpleName() + "@"
+				+ slotIndex + ", button=" + button + ", action=" + action
+				+ ", stack=" + slot.getStack());
+
+		if (action > 1 || button > 1 || !slot.getHasStack()) {
+			return;
+		}
+
+		ItemStack heldStack = mc.thePlayer.inventory.getItemStack();
+		ItemStack slotStack = slot.getStack();
+
+		WrappedRecipe recipe = null;
+		int recipeIndex = slotIndex + currentRowOffset * 8;
+		if (recipeIndex >= 0 && shownRecipes != null
+				&& recipeIndex < shownRecipes.size()) {
+			WrappedRecipe r = shownRecipes.get(recipeIndex);
+			if (StackUtils.areEqualNoSizeNoNBT(r.getOutput(), slotStack)
+					&& craftableRecipes != null && craftableRecipes.contains(r)) {
+				recipe = r;
+			}
+		}
+		if (recipe == null) {
+			return;
+		}
+
+		// slotStack already has a stack from recipe.handler.getCraftingResult()
+		ItemStack finalStack = slotStack.copy();
+		int finalStackSize = 0;
+
+		if (heldStack == null) {
+			finalStackSize = finalStack.stackSize;
+		} else if (StackUtils.canStack(slotStack, heldStack) == 0) {
+			finalStackSize = finalStack.stackSize + heldStack.stackSize;
+		}
+
+		if (finalStackSize > 0) {
+			boolean isRightClick = button == 1;
+			boolean isShiftClick = action == 1;
+
+			PacketHandler.INSTANCE.sendToServer(new MessageEasyCrafting(recipe,
+					isRightClick, isShiftClick));
+
+			if (isRightClick) { // Right click; craft until max stack
+				int maxTimes = RecipeHelper
+						.calculateCraftingMultiplierUntilMaxStack(slotStack,
+								heldStack);
+				int timesCrafted = RecipeHelper.canCraft(recipe,
+						mc.thePlayer.inventory, RecipeManager.getAllRecipes(),
+						false, maxTimes, ConfigHandler.MAX_RECURSION);
+				if (timesCrafted > 0) {
+					finalStack.stackSize = finalStackSize + (timesCrafted - 1)
+							* finalStack.stackSize;
+					mc.thePlayer.inventory.setItemStack(finalStack);
+				}
+			} else if (isShiftClick) {
+				int maxTimes = RecipeHelper
+						.calculateCraftingMultiplierUntilMaxStack(slotStack,
+								null);
+				int timesCrafted = RecipeHelper.canCraft(recipe,
+						mc.thePlayer.inventory, RecipeManager.getAllRecipes(),
+						false, maxTimes, ConfigHandler.MAX_RECURSION);
+				if (timesCrafted > 0) {
+					finalStack.stackSize *= timesCrafted; // ignore
+															// finalStackSize;
+															// it might contain
+															// heldStack size
+					InventoryUtils.addItemToInventory(mc.thePlayer.inventory,
+							finalStack);
+				}
+			} else { // Left click; craft once
+				finalStack.stackSize = finalStackSize;
+				mc.thePlayer.inventory.setItemStack(finalStack);
+			}
+		}
+	}
+
+	private void drawSlotBackground(Slot slot, boolean canCraft) {
+		int x = guiLeft + slot.xDisplayPosition;
+		int y = guiTop + slot.yDisplayPosition;
+		int color = canCraft ? 0x8000A000 : 0x80A00000;
+		Gui.drawRect(x, y, x + 16, y + 16, color);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void updateSearch(boolean scrollToTop) {
+		List<WrappedRecipe> all = currentTab == 0 ? craftableRecipes
+				: RecipeManager.getAllRecipes();
+		List<WrappedRecipe> list = new ArrayList<WrappedRecipe>();
+		if (all == null || searchField == null) {
+			return;
+		}
+		LAST_SEARCH = searchField.getText().toLowerCase();
+		if (!LAST_SEARCH.trim().isEmpty()) {
+			for (WrappedRecipe recipe : all) {
+				List<String> tips = recipe.getOutput().getTooltip(mc.thePlayer,
+						mc.gameSettings.advancedItemTooltips);
+				for (String tip : tips) {
+					if (tip.toLowerCase().contains(LAST_SEARCH)) {
+						list.add(recipe);
+						break;
+					}
+				}
+			}
+			shownRecipes = list;
+		} else {
+			shownRecipes = all;
+		}
+
+		maxRowOffset = (int) (Math.ceil(shownRecipes.size() / 8.0D) - 5);
+		maxRowOffset = maxRowOffset < 0 ? 0 : maxRowOffset;
+
+		rebuildCanCraftCache();
+		setRowOffset(scrollToTop ? 0 : currentRowOffset);
+	}
+
+	public void refreshCraftingOutput() {
+		craftableRecipes = ImmutableList.copyOf(RecipeChecker.INSTANCE.recipes);
+		updateSearch(false);
+	}
+
+	private void rebuildCanCraftCache() {
+		canCraftCache = new boolean[shownRecipes.size()];
+		for (int i = 0; i < shownRecipes.size(); i++) {
+			canCraftCache[i] = craftableRecipes.contains(shownRecipes.get(i));
+		}
+	}
+
+	private void setRowOffset(int rowOffset) {
+		currentRowOffset = MathHelper.clamp_int(rowOffset, 0, maxRowOffset);
+		currentScrollValue = MathHelper.clamp_float(currentRowOffset
+				/ (float) maxRowOffset, 0F, 1F);
+		setSlots();
+	}
+
+	private void setScrollValue(float scrollValue) {
+		currentScrollValue = MathHelper.clamp_float(scrollValue, 0F, 1F);
+		currentRowOffset = MathHelper.clamp_int((int) (currentScrollValue
+				* maxRowOffset + 0.5F), 0, maxRowOffset);
+		setSlots();
+	}
+
+	private void setSlots() {
+		if (shownRecipes != null) {
+			int offset = currentRowOffset * 8;
+			for (int i = 0; i < 40; i++) {
+				if (i + offset >= shownRecipes.size() || i + offset < 0) {
+					tileInventory.setInventorySlotContents(i, null);
+				} else {
+					WrappedRecipe recipe = shownRecipes.get(i + offset);
+					ItemStack is = recipe.handler.getCraftingResult(recipe,
+							recipe.usedIngredients);
+					tileInventory.setInventorySlotContents(i, is);
+				}
+			}
+		}
+	}
+
+	// START NEI
+	@Override
+	public List<String> handleTooltip(GuiContainer gui, int mouseX, int mouseY,
+			List<String> currentTip) {
+		return currentTip;
+	}
+
+	@Override
+	public List<String> handleItemDisplayName(GuiContainer gui,
+			ItemStack stack, List<String> currentTip) {
+		return currentTip;
+	}
+
+	@Override
+	public List<String> handleItemTooltip(GuiContainer gui, ItemStack stack,
+			int mouseX, int mouseY, List<String> currentTip) {
+		if (!drawCustomTooltip(stack, mouseX, mouseY, currentTip)) {
+			return currentTip;
+		}
+		// Hack to always return empty list
+		return new LinkedList<String>() {
+			@Override
+			public int size() {
+				return 0;
+			}
+		};
+	}
+
+	// END NEI
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected void renderToolTip(ItemStack stack, int mouseX, int mouseY) {
+		if (!drawCustomTooltip(stack, mouseX, mouseY,
+				(List<String>) stack.getTooltip(mc.thePlayer,
+						mc.gameSettings.advancedItemTooltips))) {
+			super.renderToolTip(stack, mouseX, mouseY);
+		}
+	}
+
+	private boolean drawCustomTooltip(ItemStack stack, int mouseX, int mouseY,
+			List<String> currentTip) {
+		if (isCtrlKeyDown() && currentTip != null && !currentTip.isEmpty()) {
+			for (int j = 0; j < 40; j++) {
+				Slot slot = inventorySlots.getSlot(j);
+				// isPointInRegion
+				if (func_146978_c(slot.xDisplayPosition, slot.yDisplayPosition,
+						16, 16, mouseX, mouseY)) {
+					FontRenderer font = stack.getItem().getFontRenderer(stack);
+					String itemName = currentTip.get(0);
+					List<String> list = ImmutableList
+							.of(stack.getRarity().rarityColor + itemName);
+					drawHoveringText(list, mouseX, mouseY,
+							font == null ? fontRendererObj : font);
+
+					boolean leftSide = mouseX + 12
+							+ fontRendererObj.getStringWidth(itemName) > width;
+					drawIngredientTooltip(j, mouseX, mouseY, leftSide);
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private void drawIngredientTooltip(int slotIndex, int mouseX, int mouseY,
+			boolean leftSide) {
+
+		WrappedRecipe recipe = null;
+
+		int recipe_index = slotIndex + currentRowOffset * 8;
+		if (recipe_index >= 0 && shownRecipes != null
+				&& recipe_index < shownRecipes.size()) {
+			WrappedRecipe r = shownRecipes.get(recipe_index);
+			if (StackUtils.areCraftingEquivalent(r.getOutput(), inventorySlots
+					.getSlot(slotIndex).getStack())) {
+				recipe = r;
+			}
+		}
+
+		if (recipe == null) {
+			return;
+		}
+
+		boolean canCraft = canCraftCache[recipe_index];
+		List<WrappedStack> ingredientList = canCraft
+				&& !recipe.usedIngredients.isEmpty() ? StackUtils
+				.collateStacks(recipe.usedIngredients) : recipe.collatedInputs;
+
+		if (ingredientList != null && !ingredientList.isEmpty()) {
+			int width = 16;
+			int height = 16;
+			int xPos = mouseX + 12;
+			int yPos = mouseY - 12 + 14;
+
+			if (ingredientList.size() > 1) {
+				width += (ingredientList.size() - 1) * (width + 2);
+			}
+
+			if (leftSide) {
+				xPos -= 28 + width;
+			}
+
+			// red: 0x50FF0000;// green: 0x5000A700;// vanilla purple:
+			// 0x505000FF;
+			int bgColor = 0xF0100010;
+			int borderColor = canCraft ? 0x5000A700 : 0x50FF0000;
+			int borderColorDark = (borderColor & 0xFEFEFE) >> 1 | borderColor
+					& 0xFF000000;
+
+			zLevel += 500.0F;
+			itemRender.zLevel += 500.0F;
+
+			RenderHelper.disableStandardItemLighting();
+			GL11.glDisable(GL11.GL_LIGHTING);
+			GL11.glDisable(GL11.GL_DEPTH_TEST);
+			GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+
+			drawGradientRect(xPos - 3, yPos - 4, xPos + width + 3, yPos - 3,
+					bgColor, bgColor);
+			drawGradientRect(xPos - 3, yPos + height + 3, xPos + width + 3,
+					yPos + height + 4, bgColor, bgColor);
+			drawGradientRect(xPos - 3, yPos - 3, xPos + width + 3, yPos
+					+ height + 3, bgColor, bgColor);
+			drawGradientRect(xPos - 4, yPos - 3, xPos - 3, yPos + height + 3,
+					bgColor, bgColor);
+			drawGradientRect(xPos + width + 3, yPos - 3, xPos + width + 4, yPos
+					+ height + 3, bgColor, bgColor);
+
+			drawGradientRect(xPos - 3, yPos - 3 + 1, xPos - 3 + 1, yPos
+					+ height + 3 - 1, borderColor, borderColorDark);
+			drawGradientRect(xPos + width + 2, yPos - 3 + 1, xPos + width + 3,
+					yPos + height + 3 - 1, borderColor, borderColorDark);
+			drawGradientRect(xPos - 3, yPos - 3, xPos + width + 3,
+					yPos - 3 + 1, borderColor, borderColor);
+			drawGradientRect(xPos - 3, yPos + height + 2, xPos + width + 3,
+					yPos + height + 3, borderColorDark, borderColorDark);
+
+			RenderHelper.enableGUIStandardItemLighting();
+			GL11.glEnable(GL11.GL_LIGHTING);
+			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+
+			for (WrappedStack ws : ingredientList) {
+				renderItem(xPos, yPos, ws);
+				xPos += 18;
+			}
+
+			GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+			GL11.glDisable(GL11.GL_DEPTH_TEST);
+			GL11.glDisable(GL11.GL_LIGHTING);
+
+			zLevel -= 500.0F;
+			itemRender.zLevel -= 500.0F;
+		}
+	}
+
+	private void renderItem(int xPos, int yPos, WrappedStack ws) {
+		ItemStack is = null;
+
+		int count = 0;
+		for (ItemStack stack : ws.stacks) {
+			if (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE
+					&& stack.getHasSubtypes()) {
+				count += ItemMap.get(stack.getItem()).size();
+			} else {
+				count++;
+			}
+		}
+
+		int num = (int) ((mc.theWorld.getTotalWorldTime() / 10) % count);
+
+		count = 0;
+		for (ItemStack stack : ws.stacks) {
+			if (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE
+					&& stack.getHasSubtypes()) {
+				List<ItemStack> all = ItemMap.get(stack.getItem());
+				if (num >= count && num < count + all.size()) {
+					is = StackUtils.copyStack(all.get(num - count), ws.size);
+					break;
+				}
+				count += all.size();
+			} else {
+				if (num == count) {
+					is = StackUtils.copyStack(stack, ws.size);
+					break;
+				}
+				count++;
+			}
+		}
+
+		//
+		if (is != null) {
+			itemRender.renderItemAndEffectIntoGUI(fontRendererObj,
+					mc.renderEngine, is, xPos, yPos);
+			itemRender.renderItemOverlayIntoGUI(fontRendererObj,
+					mc.renderEngine, is, xPos, yPos);
+		} else {
+			Ref.LOGGER
+					.warn("Error rendering stack in recipe tooltip: is == null");
+		}
+	}
 }

--- a/src/main/java/net/lepko/easycrafting/core/proxy/ProxyClient.java
+++ b/src/main/java/net/lepko/easycrafting/core/proxy/ProxyClient.java
@@ -1,23 +1,29 @@
 package net.lepko.easycrafting.core.proxy;
 
-import cpw.mods.fml.common.FMLCommonHandler;
 import net.lepko.easycrafting.core.CommandEasyCrafting;
+import net.lepko.easycrafting.core.block.ModBlocks;
 import net.lepko.easycrafting.core.recipe.RecipeChecker;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
 import net.minecraftforge.client.ClientCommandHandler;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class ProxyClient extends Proxy {
 
-    @Override
-    public void registerHandlers() {
-        super.registerHandlers();
+	@Override
+	public void registerHandlers() {
+		super.registerHandlers();
 
-        FMLCommonHandler.instance().bus().register(RecipeChecker.INSTANCE);
-    }
+		FMLCommonHandler.instance().bus().register(RecipeChecker.INSTANCE);
+	}
 
-    @Override
-    public void registerCommands() {
-        super.registerCommands();
+	@Override
+	public void registerCommands() {
+		super.registerCommands();
 
-        ClientCommandHandler.instance.registerCommand(new CommandEasyCrafting());
-    }
+		ClientCommandHandler.instance
+				.registerCommand(new CommandEasyCrafting());
+	}
 }

--- a/src/main/resources/assets/easycrafting/lang/en_US.lang
+++ b/src/main/resources/assets/easycrafting/lang/en_US.lang
@@ -7,3 +7,8 @@ mode.easycrafting:pulse.tooltip=Craft once every pulse
 mode.easycrafting:always.tooltip=Always on
 mode.easycrafting:powered.tooltip=Craft with signal
 mode.easycrafting:unpowered.tooltip=Craft without signal
+
+key.focus=Search Focus
+key.categories.easycrafting=Easy Crafting
+
+itemGroup.easyCrafting=Easy Crafting


### PR DESCRIPTION
The GUI for Easy Crafting Table has the search bar as default off. If
you press the key binding to focus the search bar (default 'F') the
search bar will focus. If you click on anywhere but the search bar, you
will lose focus but your search content will be saved. If you right
click on the search bar the entire search bar will be emptied. If the
search bar is focused the escape key will clear the search bar and
remove focus. Pressing escape again will close the gui. Also holding
doing the escape key will close the gui.

Should probably make a config to set a default whether the search bar
should be focused on open or not.

Added a tab to easy crafting. Maybe make this tab part of the config?

Other things to consider:
-The server (probably client as well) has major duplication bugs when
shift clicking an item that already exists on your inventory. If you
have 9 diamonds and you shift click the option to craft nine diamonds,
you will generate an entire stack of diamonds. I recommend better safe
checking, but I cannot easily make out how the recipe handler works
without rewriting most of it. I highly recommend lepko take a look at
this.
-Using a small amount of mods is ok for the crafting table. However when
using a large amount of mods the crafting table will be ok unless you
have a lot of ingredients in your inventory. This could probably be
fixed by a lazy loader. Instead of waiting for the recipe handler to
load all new possible crafts, update the list every so often. Again, I
would do this if I could make sense of the handler, but alas would
probably be too much work, also recommend lepko to take a look at this.
-I didn't touch the Auto crafting table because personally I don't use
it so I have no idea how it works. I don't think I ever opened it
either. Anyone is welcome to move changes made to GuiEasyCrafting to
GuiAutoCrafting.