### PR TITLE
Fixed dark UI issue on newer versions of Forge

### DIFF
--- a/src/main/java/net/lepko/easycrafting/core/inventory/gui/GuiAutoCrafting.java
+++ b/src/main/java/net/lepko/easycrafting/core/inventory/gui/GuiAutoCrafting.java
@@ -1,5 +1,7 @@
 package net.lepko.easycrafting.core.inventory.gui;
 
+import org.lwjgl.opengl.GL11;
+
 import net.lepko.easycrafting.Ref;
 import net.lepko.easycrafting.core.block.TileEntityAutoCrafting;
 import net.lepko.easycrafting.core.inventory.ContainerAutoCrafting;
@@ -30,6 +32,7 @@ public class GuiAutoCrafting extends GuiContainer {
 
     @Override
     protected void drawGuiContainerBackgroundLayer(float tickTime, int mouseX, int mouseY) {
+    	GL11.glColor4f(1, 1, 1, 1);
         // Background
         mc.renderEngine.bindTexture(GUI_TEXTURE);
         drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);

--- a/src/main/java/net/lepko/easycrafting/core/inventory/gui/GuiEasyCrafting.java
+++ b/src/main/java/net/lepko/easycrafting/core/inventory/gui/GuiEasyCrafting.java
@@ -132,9 +132,11 @@ public class GuiEasyCrafting extends GuiTabbed implements IContainerTooltipHandl
 
     @Override
     protected void drawGuiContainerBackgroundLayer(float f, int i, int j) {
+        GL11.glColor4f(1, 1, 1, 1);
         // Background
         mc.renderEngine.bindTexture(GUI_TEXTURE);
         drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
+        GL11.glColor4f(1, 1, 1, 1);
 
         // Tabs
         super.drawGuiContainerBackgroundLayer(f, i, j);


### PR DESCRIPTION
On (at least) Forge 10.13.2.1230, the GUI for both crafting tables
renders really dark. I added a GL line to fix this, into each GUI file.
