### PR TITLE
fix inventory update event

### DIFF
--- a/src/main/java/net/lepko/easycrafting/core/block/TileEntityAutoCrafting.java
+++ b/src/main/java/net/lepko/easycrafting/core/block/TileEntityAutoCrafting.java
@@ -300,6 +300,7 @@ public class TileEntityAutoCrafting extends TileEntity implements ISidedInventor
 
     @Override
     public void setInventorySlotContents(int slotIndex, ItemStack stack) {
+        inventoryChanged = true;
         inventory[slotIndex] = stack;
     }
 


### PR DESCRIPTION
Hi, i resolved issue what happens with some Pipe mods.

For example: ProjectRed pipes do not a calls markDirty() method after inventory update via setInventorySlotContents 
